### PR TITLE
PRODSECKB-5586: Add Dependabot setting file

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,76 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+registries:
+  cloudsmith-maven:
+    type: maven-repository
+    url: https://maven.cloudsmith.io/tricentis/qtest/
+    namespace: tricentis
+    service-slug: qtest-ci
+    audience: https://github.com/Tricentis-qTest/
+    replaces-base: true
+  cloudsmith-nuget:
+    type: nuget-feed
+    url: https://nuget.cloudsmith.io/tricentis/qtest/
+    namespace: tricentis
+    service-slug: qtest-ci
+    audience: https://github.com/Tricentis-qTest/
+    replaces-base: true
+updates:
+  - package-ecosystem: maven
+    directories:
+      - "/**/*"
+    schedule:
+      interval: "daily"
+    registries:
+      - cloudsmith-maven
+    groups:
+      maven-minor:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
+  - package-ecosystem: gradle
+    directories:
+      - "/**/*"
+    schedule:
+      interval: "daily"
+    registries:
+      - cloudsmith-maven
+    groups:
+      gradle-minor:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
+  - package-ecosystem: nuget
+    directories:
+      - "/**/*"
+    schedule:
+      interval: "daily"
+    registries:
+      - cloudsmith-nuget
+    groups:
+      nuget-minor:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,8 +25,12 @@ updates:
       - "/**/*"
     schedule:
       interval: "daily"
+    cooldown:
+      default-days: 3
     registries:
       - cloudsmith-maven
+    commit-message:
+      prefix: "QTEST-39880"
     groups:
       maven-minor:
         patterns:
@@ -43,8 +47,12 @@ updates:
       - "/**/*"
     schedule:
       interval: "daily"
+    cooldown:
+      default-days: 3
     registries:
       - cloudsmith-maven
+    commit-message:
+      prefix: "QTEST-39880"
     groups:
       gradle-minor:
         patterns:
@@ -61,8 +69,12 @@ updates:
       - "/**/*"
     schedule:
       interval: "daily"
+    cooldown:
+      default-days: 3
     registries:
       - cloudsmith-nuget
+    commit-message:
+      prefix: "QTEST-39880"
     groups:
       nuget-minor:
         patterns:


### PR DESCRIPTION
﻿## PRODSECKB-5586: Add Dependabot setting file

Adds `.github/dependabot.yml` to enable Dependabot version updates for the package ecosystems detected in this repository (maven, gradle, nuget).

- Private Cloudsmith registries via OIDC (`replaces-base: true`)
- Grouped **minor/patch** updates, daily schedule; major updates ignored
- npm split per component directory; other ecosystems use the `/**/*` wildcard

See the [Dependabot Setup Guide](https://tricentis.atlassian.net/wiki/spaces/PRODSECKB/pages/3415539895/Dependabot+Setup+Guide) for details.
